### PR TITLE
Index canClaim column for faster queries

### DIFF
--- a/prisma/migrations/20230706035817_index_can_claim/migration.sql
+++ b/prisma/migrations/20230706035817_index_can_claim/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Azuki_canClaim_idx" ON "Azuki"("canClaim");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,4 +13,6 @@ model Azuki {
   canClaim  Boolean  @default(true)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([canClaim])
 }


### PR DESCRIPTION
Query to fetch all unclaimed Azukis are (slightly) faster now